### PR TITLE
uses should bind json instead of bind json

### DIFF
--- a/controllers/article.go
+++ b/controllers/article.go
@@ -27,7 +27,7 @@ func (ctrl ArticleController) Create(c *gin.Context) {
 
 	var articleForm forms.ArticleForm
 
-	if c.BindJSON(&articleForm) != nil {
+	if c.ShouldBindJSON(&articleForm) != nil {
 		c.JSON(http.StatusNotAcceptable, gin.H{"message": "Invalid form", "form": articleForm})
 		c.Abort()
 		return
@@ -106,7 +106,7 @@ func (ctrl ArticleController) Update(c *gin.Context) {
 
 		var articleForm forms.ArticleForm
 
-		if c.BindJSON(&articleForm) != nil {
+		if c.ShouldBindJSON(&articleForm) != nil {
 			c.JSON(http.StatusNotAcceptable, gin.H{"message": "Invalid parameters", "form": articleForm})
 			c.Abort()
 			return

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -40,7 +40,7 @@ func getSessionUserInfo(c *gin.Context) (userSessionInfo models.UserSessionInfo)
 func (ctrl UserController) Signin(c *gin.Context) {
 	var signinForm forms.SigninForm
 
-	if c.BindJSON(&signinForm) != nil {
+	if c.ShouldBindJSON(&signinForm) != nil {
 		c.JSON(http.StatusNotAcceptable, gin.H{"message": "Invalid form", "form": signinForm})
 		c.Abort()
 		return
@@ -65,7 +65,7 @@ func (ctrl UserController) Signin(c *gin.Context) {
 func (ctrl UserController) Signup(c *gin.Context) {
 	var signupForm forms.SignupForm
 
-	if c.BindJSON(&signupForm) != nil {
+	if c.ShouldBindJSON(&signupForm) != nil {
 		c.JSON(http.StatusNotAcceptable, gin.H{"message": "Invalid form", "form": signupForm})
 		c.Abort()
 		return

--- a/tests/article_test.go
+++ b/tests/article_test.go
@@ -130,7 +130,7 @@ func TestSignupInvalidEmail(t *testing.T) {
 	resp := httptest.NewRecorder()
 
 	testRouter.ServeHTTP(resp, req)
-	assert.Equal(t, resp.Code, 400) //406
+	assert.Equal(t, resp.Code, 406)
 }
 
 /**
@@ -237,7 +237,7 @@ func TestCreateInvalidArticle(t *testing.T) {
 	resp := httptest.NewRecorder()
 
 	testRouter.ServeHTTP(resp, req)
-	assert.Equal(t, resp.Code, 400) //406
+	assert.Equal(t, resp.Code, 406)
 }
 
 /**


### PR DESCRIPTION
hey!

great template!  I saw your comment with `//406` and I couldn't help but wonder why.

This [doc](https://github.com/gin-gonic/gin/blob/master/README.md#model-binding-and-validation) suggests that bindJSON automatically sets it to 400 and then does an abort  so when you set code to 406 that doesn't do anything.