### PR TITLE
Replaced twinj/uuid & myesui/uuid with google/uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,15 +11,14 @@ require (
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.1.0
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/joho/godotenv v1.3.0
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/lib/pq v1.5.2
 	github.com/mattn/go-isatty v0.0.13 // indirect
 	github.com/mattn/go-sqlite3 v1.14.8 // indirect
-	github.com/myesui/uuid v1.0.0 // indirect
 	github.com/poy/onpar v1.1.2 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/twinj/uuid v1.0.0
 	github.com/ugorji/go v1.2.6 // indirect
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=

--- a/main.go
+++ b/main.go
@@ -11,8 +11,8 @@ import (
 	"github.com/Massad/gin-boilerplate/db"
 	"github.com/Massad/gin-boilerplate/forms"
 	"github.com/gin-contrib/gzip"
+	uuid "github.com/google/uuid"
 	"github.com/joho/godotenv"
-	uuid "github.com/twinj/uuid"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
@@ -42,7 +42,7 @@ func CORSMiddleware() gin.HandlerFunc {
 //Generate a unique ID and attach it to each request for future reference or use
 func RequestIDMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		uuid := uuid.NewV4()
+		uuid := uuid.New()
 		c.Writer.Header().Set("X-Request-Id", uuid.String())
 		c.Next()
 	}

--- a/models/auth.go
+++ b/models/auth.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/Massad/gin-boilerplate/db"
 	jwt "github.com/golang-jwt/jwt/v4"
-	uuid "github.com/twinj/uuid"
+	uuid "github.com/google/uuid"
 )
 
 //TokenDetails ...
@@ -43,10 +43,10 @@ func (m AuthModel) CreateToken(userID int64) (*TokenDetails, error) {
 
 	td := &TokenDetails{}
 	td.AtExpires = time.Now().Add(time.Minute * 15).Unix()
-	td.AccessUUID = uuid.NewV4().String()
+	td.AccessUUID = uuid.New().String()
 
 	td.RtExpires = time.Now().Add(time.Hour * 24 * 7).Unix()
-	td.RefreshUUID = uuid.NewV4().String()
+	td.RefreshUUID = uuid.New().String()
 
 	var err error
 	//Creating Access Token


### PR DESCRIPTION
Replace the repos used to create uuid with github.com/google/uuid due to missing dependencies which caused failures.
Closes #20 